### PR TITLE
Clean accordion text & fix disappearing custom controls

### DIFF
--- a/octoprint_v8theme/static/js/v8theme.js
+++ b/octoprint_v8theme/static/js/v8theme.js
@@ -106,10 +106,14 @@ $(function() {
       if (typeof self.temperature.plot !== "undefined") self.temperature.plot.unhighlight();
     }
 
-    self.parseCustomControls = function() {
+    self.customControls.onEventSettingsUpdated = function (payload) {
       $(".parsed-control").each(function() {
         $(this).remove();
       });
+      self.customControls.requestData();
+    }
+
+    self.parseCustomControls = function() {
       $("#control .custom_section").each(function() {
         var accordionName = $(this).find('h1 span').text();
         accordionNameClean = accordionName.replace(/[^a-zA-Z0-9]/g,'');

--- a/octoprint_v8theme/static/js/v8theme.js
+++ b/octoprint_v8theme/static/js/v8theme.js
@@ -112,24 +112,24 @@ $(function() {
       });
       $("#control .custom_section").each(function() {
         var accordionName = $(this).find('h1 span').text();
-        accordionName_nospace = accordionName.replace(/\s+/g, '');
-        $("#terminal_wrapper").after("<div id='" + accordionName_nospace + "_wrapper' class='accordion-group parsed-control'><div class='accordion-heading'><a class='accordion-toggle custom-control-toggle' data-toggle='collapse' data-target='#" + accordionName_nospace + "_main'><i class='icon-info-sign'></i> " + accordionName + " </a></div><div id='" + accordionName_nospace + "_main' class='accordion-body collapse in '><div class='accordion-inner'></div></div>");
+        accordionNameClean = accordionName.replace(/[^a-zA-Z0-9]/g,'');
+        $("#terminal_wrapper").after("<div id='" + accordionNameClean + "_wrapper' class='accordion-group parsed-control'><div class='accordion-heading'><a class='accordion-toggle custom-control-toggle' data-toggle='collapse' data-target='#" + accordionNameClean + "_main'><i class='icon-info-sign'></i> " + accordionName + " </a></div><div id='" + accordionNameClean + "_main' class='accordion-body collapse in '><div class='accordion-inner'></div></div>");
         var elementHorizontal = $(this).find('.custom_section_horizontal'), elementHorizontalGrid = $(this).find('.custom_section_horizontal_grid'), elementVertical = $(this).find('.custom_section_vertical');
         if (elementHorizontal.length) {
           if (elementHorizontal.hasClass('hide')) {
-            $("#" + accordionName_nospace + "_main").removeClass('in');
+            $("#" + accordionNameClean + "_main").removeClass('in');
           }
-          elementHorizontal.appendTo("#" + accordionName_nospace + "_main .accordion-inner");
+          elementHorizontal.appendTo("#" + accordionNameClean + "_main .accordion-inner");
         } else if (elementVertical.length) {
           if (elementVertical.hasClass('hide')) {
-            $("#" + accordionName_nospace + "_main").removeClass('in');
+            $("#" + accordionNameClean + "_main").removeClass('in');
           }
-          elementVertical.appendTo("#" + accordionName_nospace + "_main .accordion-inner");
+          elementVertical.appendTo("#" + accordionNameClean + "_main .accordion-inner");
         } else if (elementHorizontalGrid.length) {
           if (elementHorizontalGrid.hasClass('hide')) {
-            $("#" + accordionName_nospace + "_main").removeClass('in');
+            $("#" + accordionNameClean + "_main").removeClass('in');
           }
-          elementHorizontalGrid.appendTo("#" + accordionName_nospace + "_main .accordion-inner");
+          elementHorizontalGrid.appendTo("#" + accordionNameClean + "_main .accordion-inner");
         }
         $(this).remove();
       });

--- a/octoprint_v8theme/static/js/v8theme.js
+++ b/octoprint_v8theme/static/js/v8theme.js
@@ -117,7 +117,8 @@ $(function() {
       $("#control .custom_section").each(function() {
         var accordionName = $(this).find('h1 span').text();
         accordionNameClean = accordionName.replace(/[^a-zA-Z0-9]/g,'');
-        $("#terminal_wrapper").after("<div id='" + accordionNameClean + "_wrapper' class='accordion-group parsed-control'><div class='accordion-heading'><a class='accordion-toggle custom-control-toggle' data-toggle='collapse' data-target='#" + accordionNameClean + "_main'><i class='icon-info-sign'></i> " + accordionName + " </a></div><div id='" + accordionNameClean + "_main' class='accordion-body collapse in '><div class='accordion-inner'></div></div>");
+        $("#terminal_wrapper").after("<div id='" + accordionNameClean + "_wrapper' class='accordion-group parsed-control'><div class='accordion-heading'><a class='accordion-toggle custom-control-toggle' data-toggle='collapse' data-target='#" + accordionNameClean + "_main'><i class='icon-info-sign'></i><span></span></a></div><div id='" + accordionNameClean + "_main' class='accordion-body collapse in '><div class='accordion-inner'></div></div>");
+        $("#" + accordionNameClean + "_wrapper .accordion-heading span").text(accordionName);
         var elementHorizontal = $(this).find('.custom_section_horizontal'), elementHorizontalGrid = $(this).find('.custom_section_horizontal_grid'), elementVertical = $(this).find('.custom_section_vertical');
         if (elementHorizontal.length) {
           if (elementHorizontal.hasClass('hide')) {


### PR DESCRIPTION
Today @eroneill  brought to my attention the issue with Tacky Tangerine where someone added a forward slash inside the title of a custom command. For example: `Activate/Deactivate`.  

This was causing an issue with `self.parseCustomControls`.

Now, we clean each accordion name which solves this problem.

Additionally, when you open the settings dialog and hit cancel, the parse function for custom controls would delete the custom controls but not parse in new ones. Now, we only delete old controls upon save complete.

cc: @jminardi @eroneill 
