### PR TITLE
Unhide additional tabs inside main content wrapper

### DIFF
--- a/octoprint_v8theme/static/css/main.css
+++ b/octoprint_v8theme/static/css/main.css
@@ -359,6 +359,12 @@ a.accordion-toggle {
   top: 2px;
   right: 0;
 }
+.tab-content.main-content-wrapper {
+  padding: 0;
+}
+.main-content-wrapper>.tab-pane {
+  display: block;
+}
 /*===================================================
    D. Buttons
 =================================================== */


### PR DESCRIPTION
Unhides tabs that are placed inside the additional content wrapper.
cc: @jminardi @maxvoxel8 
