### PR TITLE
Make homing button send G28, G29 command

### DIFF
--- a/octoprint_v8theme/static/css/main.css
+++ b/octoprint_v8theme/static/css/main.css
@@ -814,8 +814,9 @@ input[type="text"].search-query {
 =================================================== */
 .control-panel-left .jog-panel {
   display: inline-block;
-  margin-right: 19px;
+  margin-right: 22px;
   text-align: center;
+  vertical-align: middle;
 }
 .control-panel-right .jog-panel {
   float: left;
@@ -930,6 +931,12 @@ input[type="text"].search-query {
 }
 .control-panel-left .box, .control-panel-right .box {
   padding-top: 4px;
+}
+#control-zhome {
+  display: none!important;
+}
+#control-zinc, #control-zdec {
+  height: 50px!important;
 }
 /* ================================================
     V. COLOR SYSTEM

--- a/octoprint_v8theme/static/js/v8theme.js
+++ b/octoprint_v8theme/static/js/v8theme.js
@@ -137,10 +137,16 @@ $(function() {
       if (typeof self.temperature.plot !== "undefined") self.temperature.plot.unhighlight();
     }
 
+    /* Modified from OctoPrint
+     * Reason: Change homing button to run G28 & G29 instead of built in homing function
+     */
     self.onBeforeBinding = function () {
       $("#customControls_containerTemplate_collapsable, #customControls_containerTemplate_nameless").html(function() {
         return $(this).html().replace(/"custom_section">/g, '"custom_section" data-bind="css: { plugin_control: (plugin_control) }">');
       });
+    };
+
+    self.control.onBeforeBinding = function () {
       $("#control-xyhome").attr("data-bind", function() {
         return $(this).attr("data-bind").replace(/sendHomeCommand\(\[\'x\', \'y\'\]\)/g, "sendCustomCommand({type:'commands',commands:['G28', 'G29']})");
       });

--- a/octoprint_v8theme/static/js/v8theme.js
+++ b/octoprint_v8theme/static/js/v8theme.js
@@ -141,6 +141,9 @@ $(function() {
       $("#customControls_containerTemplate_collapsable, #customControls_containerTemplate_nameless").html(function() {
         return $(this).html().replace(/"custom_section">/g, '"custom_section" data-bind="css: { plugin_control: (plugin_control) }">');
       });
+      $("#control-xyhome").attr("data-bind", function() {
+        return $(this).attr("data-bind").replace(/sendHomeCommand\(\[\'x\', \'y\'\]\)/g, "sendCustomCommand({type:'commands',commands:['G28', 'G29']})");
+      });
     };
 
     self.getAdditionalControls = function() {


### PR DESCRIPTION
This addresses issue #11 
The homing Z button has been removed and the only homing button that exists now runs G28 and G29.
cc: @kdumontnu @jminardi 

![image](https://cloud.githubusercontent.com/assets/10536167/13375674/f2d65148-dd73-11e5-9c25-83212a09dd04.png)
