### PR TITLE
Update theme to account for OctoPrint 1.2.9

### DIFF
--- a/octoprint_v8theme/static/css/main.css
+++ b/octoprint_v8theme/static/css/main.css
@@ -207,6 +207,9 @@ h1 small, h2 small, h3 small, h4 small, h5 small, h6 small {
   -moz-box-shadow: none;
   box-shadow: none;
 }
+#navbar .navbar-inner .brand, #navbar .navbar-inner .nav>li>a {
+  text-shadow: none;
+}
 .octoprint-container .tab-content {
   border: none;
 }
@@ -353,6 +356,9 @@ a.accordion-toggle {
   margin-right: 0;
   border-right: 0;
   padding-right: 0;
+}
+.settings-trigger {
+  margin-right: 25px;
 }
 .accordion-heading-button {
   position: absolute;
@@ -1075,6 +1081,12 @@ span.fileinput-button {
   background-image: none;
   background-color: #E4E4E4;
   color: #777777;
+}
+ul.terminal-options li>a {
+  padding: 3px 15px;
+}
+ul.terminal-options .divider {
+  margin: 5px 0;
 }
 .table-layout > div {
   display: table-cell;

--- a/octoprint_v8theme/static/js/v8theme.js
+++ b/octoprint_v8theme/static/js/v8theme.js
@@ -39,8 +39,8 @@ $(function() {
     };
 
     /* Modified from OctoPrint
-     * Reason: Edit how line numbers are displayed and created a buffer when
-     * autoscroll is disabled.
+     * Reason: Edit how line numbers are displayed and make terminal think
+     * its tab is active
      */
     self.terminal.lineCount = ko.computed(function() {
       var total = self.terminal.log().length;
@@ -60,14 +60,7 @@ $(function() {
         });
       }
     });
-    self.terminal._processCurrentLogData = function(data) {
-      self.terminal.log(self.terminal.log().concat(_.map(data, function(line) { return self.terminal._toInternalFormat(line) })));
-      if (self.terminal.autoscrollEnabled()) {
-        self.terminal.log(self.terminal.log.slice(-self.terminal.buffer()));
-      } else {
-        self.terminal.log(self.terminal.log.slice(-1000));
-      }
-    };
+    self.terminal.tabActive = true;
 
     /* Modified from OctoPrint
      * Reason: Edit color options, as well as number of ticks, and min/max values
@@ -391,7 +384,7 @@ $(function() {
       });
       $(".line-container").after($(".terminal button[data-bind*='toggleAutoscroll']").addClass("btn-default btn-sm text-light7 mr5"));
       $(".terminal-options").append("<li class='divider'></li>");
-      $("#termin-filterpanel label.checkbox").each(function() {
+      $("#terminal-filterpanel label.checkbox").each(function() {
         var commandName = $(this).find("input").attr("value").match("Send: (.*)Recv")[1];
         commandName = commandName.replace(/\(|\)|\|/g, "");
         $(this).find("span").replaceWith("<span>Supress " + commandName + "</span>");
@@ -404,7 +397,7 @@ $(function() {
       });
       $("#terminal-sendpanel .input-append input").addClass("form-control").attr("placeholder", "Enter a command...").appendTo(".terminal-textbox");
       $("#terminal-sendpanel .input-append button").addClass("btn-default btn-gradient btn-block").appendTo(".terminal-submit");
-      $("#termin-filterpanel").parent().remove();
+      $("#terminal-filterpanel").parent().remove();
       $(".terminal .pull-left, .terminal .pull-right").remove();
 
       $(".temperature-height").click(function() {


### PR DESCRIPTION
This PR makes minor CSS changes to account for different styled & new elements in 1.2.9 as well as removes code that has been implemented in the source code:
- Terminal autoscroll in 1.2.9 requires the terminal tab to be "active". Since we removed tab functionality, we make the terminal permanently think it is the active tab
- Style refresh icon and sorting icon accordingly
- Change styling of terminal option dropdown
- Remove text shadows in navbar text
- Remove custom buffer function when autoscroll is disabled as it's now implemented in the source

![image](https://cloud.githubusercontent.com/assets/10536167/13377516/4d0b05c2-ddac-11e5-95e9-451d82936cdb.png)

cc: @jminardi 
