### PR TITLE
Disable pneumatics when print is cancelled or paused

### DIFF
--- a/octoprint_v8theme/__init__.py
+++ b/octoprint_v8theme/__init__.py
@@ -4,17 +4,18 @@ from __future__ import absolute_import
 import octoprint.plugin
 import flask
 
+
 class V8themePlugin(octoprint.plugin.SettingsPlugin,
                     octoprint.plugin.AssetPlugin,
                     octoprint.plugin.SimpleApiPlugin,
                     octoprint.plugin.StartupPlugin):
 
     printer_name = ""
+
     def get_assets(self):
         return dict(
             js=['js/v8theme.js'],
-            css=['css/main.css']
-            #less=['less/my_styles.less']
+            css=['css/main.css'],
         )
 
     def get_api_commands(self):
@@ -25,21 +26,33 @@ class V8themePlugin(octoprint.plugin.SettingsPlugin,
     def on_api_command(self, command, data):
         if command == "update_printer_name":
             self.printer_name = data.get("printer_name")
-            self._plugin_manager.send_plugin_message(self._identifier, dict(printer_name=self.printer_name))
+            self._plugin_manager.send_plugin_message(
+                self._identifier, dict(printer_name=self.printer_name))
 
     def on_api_get(self, request):
         return flask.jsonify(printer_name=self.printer_name)
 
-def get_update_information(*args, **kwargs):
-    return dict(
-        v8theme=dict(
-            type="github_commit",
-            user="Voxel8",
-            repo="OctoPrint-V8theme",
-            branch='master',
-            pip="https://github.com/Voxel8/OctoPrint-V8theme/archive/{target_version}.zip",
+    # Handles turning off pneumatic devices when print is paused or cancelled
+    # Returns in the form (prefix, postfix)
+    def scripts_hook(self, comm, script_type, script_name, *args, **kwargs):
+        if (not script_type == "gcode" or
+           script_name not in ["afterPrintCancelled", "afterPrintPaused"]):
+            return None
+
+        return ["M42 P2 S0", "M42 P75 S0"], None
+
+    def get_update_information(*args, **kwargs):
+        return dict(
+            v8theme=dict(
+                type="github_commit",
+                user="Voxel8",
+                repo="OctoPrint-V8theme",
+                branch='master',
+                pip="https://github.com/Voxel8/OctoPrint-V8theme/archive/"
+                    "{target_version}.zip",
+            )
         )
-    )
+
 
 def __plugin_load__():
     global __plugin_implementation__
@@ -47,5 +60,8 @@ def __plugin_load__():
     __plugin_implementation__ = V8themePlugin()
 
     __plugin_hooks__ = {
-        "octoprint.plugin.softwareupdate.check_config": get_update_information,
+        "octoprint.plugin.softwareupdate.check_config":
+            __plugin_implementation__.get_update_information,
+        "octoprint.comm.protocol.scripts":
+            __plugin_implementation__.scripts_hook,
     }


### PR DESCRIPTION
Disables pneumatics by sending `M42 P2 S0` and `M42 P75 S0` when prints are either cancelled or paused.
cc: @dreammaker @kdumontnu 
Reference: https://github.com/Voxel8/DevKit-Issues/issues/51

Also made some style changes with pep8 guidelines in mind.
